### PR TITLE
feat: remplace "Graphiques" par "Synthèse"

### DIFF
--- a/src/components/layout/ObservatoireHead.tsx
+++ b/src/components/layout/ObservatoireHead.tsx
@@ -40,7 +40,7 @@ export function ObservatoireHead() {
 			pageTitle = 'Soumettre une démarche - Vos démarches essentielles';
 			break;
 		case '/data-viz/interministeriel':
-			pageTitle = 'Graphiques - Interministériel - Vos démarches essentielles';
+			pageTitle = 'Synthèse - Interministériel - Vos démarches essentielles';
 			break;
 		case '/data-viz/[kind]':
 		case '/data-viz/procedure':
@@ -50,7 +50,7 @@ export function ObservatoireHead() {
 					plural: true,
 					uppercaseFirst: true
 				}) || 'Démarches';
-			pageTitle = `Graphiques - ${slugTitle} - Vos démarches essentielles`;
+			pageTitle = `Synthèse - ${slugTitle} - Vos démarches essentielles`;
 			break;
 		case '/data-viz/[kind]/[slug]':
 			const { kind: kindDetail, slug } = router.query;
@@ -62,7 +62,7 @@ export function ObservatoireHead() {
 					plural: true,
 					uppercaseFirst: true
 				}) || 'Démarche';
-			pageTitle = `Graphiques - ${procedureTitle} (${kindLabel}) - Vos démarches essentielles`;
+			pageTitle = `Synthèse - ${procedureTitle} (${kindLabel}) - Vos démarches essentielles`;
 			break;
 	}
 

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -117,7 +117,7 @@ const PublicLayout = (props: Props) => {
 					},
 					{
 						isActive: router.pathname.startsWith('/data-viz'),
-						text: 'Graphiques',
+						text: 'Synthèse',
 						menuLinks: [
 							{
 								linkProps: {

--- a/src/pages/data-viz/[kind]/[slug].tsx
+++ b/src/pages/data-viz/[kind]/[slug].tsx
@@ -100,7 +100,7 @@ const DataViz = ({ kind, slug }: { kind: ProcedureKind; slug: string }) => {
 				<Breadcrumb
 					segments={[
 						{
-							label: `Graphiques - ${getProcedureKindLabel(kind, {
+							label: `Synthèse - ${getProcedureKindLabel(kind, {
 								plural: true,
 								uppercaseFirst: true
 							})}`,

--- a/src/pages/data-viz/[kind]/[slug].tsx
+++ b/src/pages/data-viz/[kind]/[slug].tsx
@@ -12,11 +12,11 @@ import { GetServerSidePropsContext } from 'next';
 import { useEffect, useState } from 'react';
 
 const evolutionLegends = [
-	'Cet histogramme représente la répartition en pourcentage des niveaux de satisfaction des démarches du domaine.',
-	'Cet histogramme représente la répartition en pourcentage du niveau d’accessibilité numérique des démarches du domaine.',
-	'Cet histogramme représente la répartition en pourcentage du niveau de simplification des démarches du domaine.',
-	'Cet histogramme représente la répartition en pourcentage des démarches de l’indicateur “Authentification”',
-	'Cet histogramme représente la répartition en pourcentage des niveaux de clarté des démarches du domaine.'
+	'Répartition en pourcentage des niveaux de satisfaction des démarches.',
+	'Répartition en pourcentage du niveau d’accessibilité numérique des démarches.',
+	'Répartition en pourcentage du niveau de simplification des démarches.',
+	'Répartition en pourcentage des démarches de l’indicateur “Authentification”',
+	'Répartition en pourcentage des niveaux de clarté des démarches.'
 ];
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {

--- a/src/pages/data-viz/[kind]/index.tsx
+++ b/src/pages/data-viz/[kind]/index.tsx
@@ -176,7 +176,7 @@ const DataViz = ({ kind }: { kind: ProcedureKind }) => {
 				<Breadcrumb
 					segments={[]}
 					homeLinkProps={{ href: '/' }}
-					currentPageLabel={`Graphiques - ${kindLabel}`}
+					currentPageLabel={`Synthèse - ${kindLabel}`}
 					className={fr.cx('fr-mb-1v')}
 				/>
 				<h1 className={cx(classes.title)}>{kindLabel}</h1>

--- a/src/pages/data-viz/interministeriel.tsx
+++ b/src/pages/data-viz/interministeriel.tsx
@@ -60,7 +60,7 @@ const Interministeriel = () => {
 				<Breadcrumb
 					segments={[]}
 					homeLinkProps={{ href: '/' }}
-					currentPageLabel="Graphiques - Interministériel"
+					currentPageLabel="Synthèse - Interministériel"
 					className={fr.cx('fr-mb-1v')}
 				/>
 				<h1>Interministériel</h1>

--- a/src/pages/data-viz/procedure/[id].tsx
+++ b/src/pages/data-viz/procedure/[id].tsx
@@ -31,14 +31,14 @@ const DataViz = ({ id }: { id: string }) => {
 	return (
 		<>
 			<Head>
-				<title>Graphiques - {procedure?.title} - Vos démarches essentielles</title>
+				<title>Synthèse - {procedure?.title} - Vos démarches essentielles</title>
 			</Head>
 			<div className={cx(classes.root)}>
 				<div className={fr.cx('fr-container', 'fr-pt-6v')}>
 					<Breadcrumb
 						segments={[
 							{
-								label: 'Graphiques - Démarches',
+								label: 'Synthèse - Démarches',
 								linkProps: { href: '/data-viz/procedure' }
 							}
 						]}

--- a/src/pages/data-viz/procedure/index.tsx
+++ b/src/pages/data-viz/procedure/index.tsx
@@ -12,7 +12,7 @@ const DataVizProcedures = () => {
 				<Breadcrumb
 					segments={[]}
 					homeLinkProps={{ href: '/' }}
-					currentPageLabel={`Graphiques - Démarches`}
+					currentPageLabel={`Synthèse - Démarches`}
 					className={fr.cx('fr-mb-1v')}
 				/>
 				<h1>Démarches</h1>


### PR DESCRIPTION
Remplace le terme **Graphiques** par **Synthèse** dans la navbar, et par cohérence dans les fils d'ariane et les titres de page associés.

## Changements
- Navbar (`PublicLayout`)
- Fils d'ariane (`currentPageLabel` / breadcrumb labels) des pages data-viz : interministériel, `[kind]`, procédure
- Titres de page (`ObservatoireHead`, `procedure/[id]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)