### PR TITLE
perf(data-viz): add compound indexes and kill query over-fetch/N+1

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,10 @@ model Procedure {
   editionId              String?  @db.ObjectId
 
   @@index([editionId])
+  @@index([editionId, title_normalized])
+  @@index([editionId, administration])
+  @@index([editionId, administration_central])
+  @@index([editionId, ministere])
 }
 
 model Field {
@@ -110,5 +114,5 @@ model Field {
   procedure    Procedure      @relation(fields: [procedureId], references: [id])
   procedureId  String         @db.ObjectId
 
-  @@index([procedureId, slug])
+  @@index([procedureId, slug, goalReached, color])
 }

--- a/src/pages/api/indicator-evolution/index.ts
+++ b/src/pages/api/indicator-evolution/index.ts
@@ -152,7 +152,7 @@ export async function getIndicatorEvolution({
 						[columnKey]: columnValue
 					},
 					include: {
-						fields: true
+						fields: { where: { slug } }
 					}
 				});
 
@@ -166,7 +166,7 @@ export async function getIndicatorEvolution({
 							: {})
 					},
 					include: {
-						fields: true
+						fields: { where: { slug } }
 					}
 				});
 
@@ -195,7 +195,7 @@ export async function getIndicatorEvolution({
 				crossValueLabel = getCrossValueLabel(cross);
 
 				if (singleValue) {
-					if (!procedures[0] || procedures[0].fields.length === 0) return;
+					if (!procedures[0]) return;
 
 					const totalValue = procedures.reduce((sum, procedure) => {
 						const field = procedure.fields.find(
@@ -236,7 +236,6 @@ export async function getIndicatorEvolution({
 				const levelCounts = indicatorLevels
 					.map(level => {
 						if (typeof level === 'string' || !level.label_stats) return null;
-						console.log(fields[0]);
 						const count = new Set(
 							fields
 								.filter(
@@ -299,7 +298,7 @@ export async function getIndicatorEvolution({
 					[columnKey]: columnValue
 				},
 				include: {
-					fields: true
+					fields: { where: { slug } }
 				}
 			});
 
@@ -311,7 +310,7 @@ export async function getIndicatorEvolution({
 						: {})
 				},
 				include: {
-					fields: true
+					fields: { where: { slug } }
 				}
 			});
 
@@ -339,7 +338,7 @@ export async function getIndicatorEvolution({
 			crossValueLabel = getCrossValueLabel(cross);
 
 			if (singleValue) {
-				if (!procedures[0] || procedures[0].fields.length === 0) return;
+				if (!procedures[0]) return;
 				return {
 					edition: edition.name,
 					levels: [

--- a/src/utils/data-viz.ts
+++ b/src/utils/data-viz.ts
@@ -210,71 +210,83 @@ export async function getAllProceduresIndicatorScores(editionId: string) {
 	const procedures = await prisma.procedure.findMany({
 		where: {
 			editionId: editionId
+		},
+		select: {
+			id: true,
+			title: true
 		}
 	});
+
+	// Single aggregation across every procedure of the edition instead of one
+	// groupBy per procedure (former N+1 that saturated the Mongo CPU).
+	const groupedFields = await prisma.field.groupBy({
+		by: ['procedureId', 'slug', 'goalReached', 'color'],
+		where: {
+			slug: {
+				in: [...validIndicatorSlugs]
+			},
+			procedureId: {
+				in: procedures.map(procedure => procedure.id)
+			},
+			goalReached: {
+				not: null
+			}
+		},
+		_count: true
+	});
+
+	const fieldsByProcedure = new Map<string, typeof groupedFields>();
+	for (const field of groupedFields) {
+		const bucket = fieldsByProcedure.get(field.procedureId) ?? [];
+		bucket.push(field);
+		fieldsByProcedure.set(field.procedureId, bucket);
+	}
 
 	const results: {
 		title: string;
 		data: { slug: string; goalReached: boolean | null }[];
-	}[] = await Promise.all(
-		procedures.map(async procedure => {
-			const fields = await prisma.field.groupBy({
-				by: ['slug', 'goalReached', 'color'],
-				where: {
-					slug: {
-						in: [...validIndicatorSlugs]
-					},
-					procedureId: procedure.id,
-					goalReached: {
-						not: null
-					}
-				},
-				orderBy: {
-					slug: 'asc'
-				},
-				_count: true
-			});
+	}[] = procedures.map(procedure => {
+		const fields = fieldsByProcedure.get(procedure.id) ?? [];
 
-			const indicators = validIndicators.map(indicator => ({
-				goalReached: null as boolean | null,
-				slug: indicator.slug
-			}));
+		const indicators = validIndicators.map(indicator => ({
+			goalReached: null as boolean | null,
+			slug: indicator.slug
+		}));
 
-			for (const slug of validIndicatorSlugs) {
-				const fieldData = fields.filter(
-					fieldData => fieldData.slug === slug && fieldData.color !== 'gray'
-				);
-				let countReached = 0;
-				let countNotReached = 0;
+		for (const slug of validIndicatorSlugs) {
+			const fieldData = fields.filter(
+				fieldData => fieldData.slug === slug && fieldData.color !== 'gray'
+			);
+			let countReached = 0;
+			let countNotReached = 0;
 
-				if (fieldData.length > 0) {
-					const reachedData = fieldData.filter(f => f.goalReached);
-					const notReachedData = fieldData.filter(f => !f.goalReached);
+			if (fieldData.length > 0) {
+				const reachedData = fieldData.filter(f => f.goalReached);
+				const notReachedData = fieldData.filter(f => !f.goalReached);
 
-					countReached = reachedData
-						? reachedData.reduce((sum, f) => sum + f._count, 0)
-						: 0;
-					countNotReached = notReachedData
-						? notReachedData.reduce((sum, f) => sum + f._count, 0)
-						: 0;
+				countReached = reachedData
+					? reachedData.reduce((sum, f) => sum + f._count, 0)
+					: 0;
+				countNotReached = notReachedData
+					? notReachedData.reduce((sum, f) => sum + f._count, 0)
+					: 0;
 
-					const totalCount = countReached + countNotReached;
+				const totalCount = countReached + countNotReached;
 
-					const score =
-						totalCount > 0 ? Math.round((countReached / totalCount) * 100) : 0;
+				const score =
+					totalCount > 0 ? Math.round((countReached / totalCount) * 100) : 0;
 
-					indicators[
-						indicators.findIndex(indicator => indicator.slug === slug)
-					].goalReached = score >= 80;
-				}
+				indicators[
+					indicators.findIndex(indicator => indicator.slug === slug)
+				].goalReached = score >= 80;
 			}
+		}
 
-			return {
-				title: procedure.title,
-				data: indicators
-			};
-		})
-	);
+		return {
+			title: procedure.title,
+			data: indicators
+		};
+	});
 
 	return results;
 }


### PR DESCRIPTION
- Procedure: index [editionId, <colonne>] pour title_normalized, administration, administration_central, ministere
- Field: index couvrant [procedureId, slug, goalReached, color]
- indicator-evolution: scope les includes fields au slug demandé (évite de charger tous les champs de toute l'édition x5 slugs)
- getAllProceduresIndicatorScores: une seule agrégation au lieu d'un groupBy par procédure (N+1)